### PR TITLE
User can supply a custom list of stopwords to TextRank

### DIFF
--- a/Sources/TextRank/Sentence.swift
+++ b/Sources/TextRank/Sentence.swift
@@ -16,10 +16,11 @@ public struct Sentence: Hashable {
 
     public let originalTextIndex: Int
 
-    public init(text: String, originalTextIndex: Int) {
+    public init(text: String, originalTextIndex: Int, additionalStopwords: [String] = [String]()) {
         self.text = text
         self.originalTextIndex = originalTextIndex
-        words = Sentence.removeStopWords(from: Sentence.clean(self.text))
+        words = Sentence.removeStopWords(from: Sentence.clean(self.text),
+                                         additionalStopwords: additionalStopwords)
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -37,9 +38,9 @@ public struct Sentence: Hashable {
             .words
     }
 
-    static func removeStopWords(from w: [String]) -> Set<String> {
+    static func removeStopWords(from w: [String], additionalStopwords: [String] = [String]()) -> Set<String> {
         var wordSet = Set(w)
-        wordSet.subtract(Stopwords.English)
+        wordSet.subtract(Stopwords.English + additionalStopwords)
         return wordSet
     }
 }

--- a/Sources/TextRank/TextRank.swift
+++ b/Sources/TextRank/TextRank.swift
@@ -18,7 +18,11 @@ public class TextRank {
     public var sentences = [Sentence]()
     public var summarizationFraction: Float = 0.2
     public var graphDamping: Float = 0.85
-    public var stopwords = [String]()
+    public var stopwords = [String]() {
+        didSet {
+            textToSentences()
+        }
+    }
 
     public init() {
         text = ""

--- a/Tests/TextRankTests/SentenceTests.swift
+++ b/Tests/TextRankTests/SentenceTests.swift
@@ -19,4 +19,38 @@ class SentenceTests: XCTestCase {
             XCTAssertEqual(s.words, Set(clean))
         }
     }
+
+    func testRemovalOfStopWords() {
+        // Given
+        let text = "here are some words to be"
+
+        // When
+        let sentence = Sentence(text: text, originalTextIndex: 0)
+
+        // Then
+        XCTAssertEqual(sentence.length, 0)
+    }
+
+    func testRemovalOfStopWordsButNotMeaningfulWords() {
+        // Given
+        let text = "here are some words to be lion"
+
+        // When
+        let sentence = Sentence(text: text, originalTextIndex: 0)
+
+        // Then
+        XCTAssertEqual(sentence.length, 1)
+        XCTAssertEqual(sentence.words, Set(["lion"]))
+    }
+
+    func testRemovalOfStopWordsAndAdditionalStopwords() {
+        // Given
+        let text = "here are some words to be lion"
+
+        // When
+        let sentence = Sentence(text: text, originalTextIndex: 0, additionalStopwords: ["lion"])
+
+        // Then
+        XCTAssertEqual(sentence.length, 0)
+    }
 }

--- a/Tests/TextRankTests/TextRankTests.swift
+++ b/Tests/TextRankTests/TextRankTests.swift
@@ -87,4 +87,40 @@ class TextRankTests: XCTestCase {
         XCTAssertTrue(filteredResults.count < results.results.count)
         XCTAssertTrue(filteredResults.count == 2)
     }
+
+    func testStopwordsAreRemoved() {
+        // Given
+        let text = "Here are some sentences dog cat. With intentional stopwords gator. And some words that are not."
+
+        // When
+        let textRank = TextRank(text: text)
+
+        // Then
+        XCTAssertEqual(textRank.sentences.count, 2)
+        XCTAssertEqual(textRank.sentences[0].length, 3)
+        XCTAssertEqual(textRank.sentences.filter { $0.originalTextIndex == 0 }[0].words,
+                       Set(["sentences", "dog", "cat"]))
+        XCTAssertEqual(textRank.sentences.filter { $0.originalTextIndex == 1 }[0].words,
+                       Set(["intentional", "stopwords", "gator"]))
+        XCTAssertEqual(textRank.sentences[1].length, 3)
+    }
+
+    func testAdditionalStopwords() {
+        // Given
+        let text = "Here are some sentences dog cat. With intentional stopwords gator. And some words that are not."
+        let additionalStopwords = ["dog", "gator"]
+
+        // When
+        let textRank = TextRank(text: text)
+        textRank.stopwords = additionalStopwords
+
+        // Then
+        XCTAssertEqual(textRank.sentences.count, 2)
+        XCTAssertEqual(textRank.sentences[0].length, 2)
+        XCTAssertEqual(textRank.sentences.filter { $0.originalTextIndex == 0 }[0].words,
+                       Set(["sentences", "cat"]))
+        XCTAssertEqual(textRank.sentences.filter { $0.originalTextIndex == 1 }[0].words,
+                       Set(["intentional", "stopwords"]))
+        XCTAssertEqual(textRank.sentences[1].length, 2)
+    }
 }


### PR DESCRIPTION
The stopwords are removed from Sentences' set of words and, thus, excluded from the similarity calculations of PageRank.